### PR TITLE
Optional Additional Flags

### DIFF
--- a/doc/statline.txt
+++ b/doc/statline.txt
@@ -45,6 +45,15 @@ See |'syntastic_stl_format'| for customization info.
 <
 
 ------------------------------------------------------------------------------
+                                                    *'statline_show_encoding'*
+
+Whether or not to show the file format and encoding type (default is on)
+Set the following to disable it: >
+
+    let g:statline_show_encoding = 0
+<
+
+------------------------------------------------------------------------------
                                                    *'statline_trailing_space'*
 
 Some languages are sensitive about trailing spaces, statline will check for

--- a/doc/statline.txt
+++ b/doc/statline.txt
@@ -38,6 +38,13 @@ See |'syntastic_stl_format'| for customization info.
 <
 
 ------------------------------------------------------------------------------
+                                                         *'statline_rvm'*
+
+|rvm| integration is disabled by default, to enable it: >
+    let g:statline_rvm = 1
+<
+
+------------------------------------------------------------------------------
                                                    *'statline_trailing_space'*
 
 Some languages are sensitive about trailing spaces, statline will check for

--- a/doc/statline.txt
+++ b/doc/statline.txt
@@ -54,6 +54,15 @@ Set the following to disable it: >
 <
 
 ------------------------------------------------------------------------------
+                                                *'statline_filename_relative'*
+
+If set, will show the relative path (from cwd) to the file, otherwise it will
+only show the filename. Set the following to show by relative paths: >
+
+    let g:statline_filename_relative = 1
+<
+
+------------------------------------------------------------------------------
                                                    *'statline_trailing_space'*
 
 Some languages are sensitive about trailing spaces, statline will check for

--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -34,8 +34,14 @@ hi default link User4 Special
 
 " buffer number (always shown)
 set statusline=[%n]\ %<
-" filename (tail)
-set statusline+=%1*[%t]%*
+
+" filename (relative or tail)
+if exists('g:statline_filename_relative')
+    set statusline+=%1*[%f]%*
+else
+    set statusline+=%1*[%t]%*
+endif
+
 " flags (h:help:[help], w:window:[Preview], m:modified:[+][-], r:readonly:[RO])
 set statusline+=%2*%h%w%m%r%*
 " filetype

--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -52,6 +52,14 @@ set statusline+=%-14(\ L%l/%L:C%c\ %)
 set statusline+=%P
 
 
+" RVM
+if !exists('g:statline_rvm')
+    let g:statline_rvm = 0
+endif
+if g:statline_rvm
+    set statusline+=%{rvm#statusline()}
+endif
+
 
 " Fugitive
 if !exists('g:statline_fugitive')

--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -40,8 +40,14 @@ set statusline+=%1*[%t]%*
 set statusline+=%2*%h%w%m%r%*
 " filetype
 set statusline+=\ %y
+
 " file format → file encoding
-set statusline+=[%{&ff}→%{strlen(&fenc)?&fenc:'No\ Encoding'}]
+if !exists('g:statline_show_encoding')
+    let g:statline_show_encoding = 1
+endif
+if g:statline_show_encoding
+    set statusline+=[%{&ff}→%{strlen(&fenc)?&fenc:'No\ Encoding'}]
+endif
 
 " separation between left/right aligned items
 set statusline+=%=


### PR DESCRIPTION
Hello Miller.
I've added 3 separate commits each addressing different items.
1. RVM support: Optional Flag to turn on rvm for the status line (off by default)
2. Optionally turn off file encoding/format for the status line
3. Optionally show the relative path to the file instead of just the tail.

These are divided into 3 commits, so it should be fairly easy to cherry pick these into their own if you don't care for all of them. These commits shouldn't affect current settings in any manner. I've also added information to the doc/statline.txt file, but not to the Readme file.

Please let me know if you have any questions. Great work on the project by the way!

thanks.
Matthew Kitt.
