### PR TITLE
Show code of character under cursor

### DIFF
--- a/doc/statline.txt
+++ b/doc/statline.txt
@@ -96,6 +96,14 @@ Mixed indent errors:~
                         marking JavaDoc style comments as mixed indent.
 
 ------------------------------------------------------------------------------
+                                                    *'statline_show_charcode'*
+
+If set, will show the code of the character currently under the cursor. It is
+disabled by default. Set the following to enable it: >
+    let g:statline_show_charcode = 1
+<
+
+------------------------------------------------------------------------------
                                                              *statline-colors*
 
 Statline adapts to your colorcheme without any extra settings but if you want

--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -71,6 +71,14 @@ set statusline+=%-14(\ L%l/%L:C%c\ %)
 " scroll percent
 set statusline+=%P
 
+" code of character under cursor
+if !exists('g:statline_show_charcode')
+    let g:statline_show_charcode = 0
+endif
+if g:statline_show_charcode
+    set statusline+=%9(\ \%b/0x\%B%)
+endif
+
 
 " ====== plugins ======
 


### PR DESCRIPTION
Make statline show the code of character under cursor in decimal
and hexadecimal after line and column information.  This can be
useful to check for mixed whitespace, non-printing characters or
UTF-8 codes.  To disable it set g:statline_show_charcode to 0.
