### PR TITLE
Allow using a different string for 'No Encoding'

### DIFF
--- a/doc/statline.txt
+++ b/doc/statline.txt
@@ -55,6 +55,16 @@ Set the following to disable it: >
 <
 
 ------------------------------------------------------------------------------
+                                               *'statline_no_encoding_string'*
+
+The text to show in the status line when the encoding is unknown (default is
+'No Encoding').
+Set it to your liking: >
+
+    let g:statline_no_encoding_string = 'NONE'
+<
+
+------------------------------------------------------------------------------
                                                 *'statline_filename_relative'*
 
 If set, will show the relative path (from cwd) to the file, otherwise it will
@@ -142,7 +152,7 @@ Other contributors:
 
  - @mkitt
  - @Idx
-
+ - @knl
 
 ==============================================================================
 4. License                                                  *statline-license*

--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -59,8 +59,11 @@ set statusline+=\ %y
 if !exists('g:statline_show_encoding')
     let g:statline_show_encoding = 1
 endif
+if !exists('g:statline_no_encoding_string')
+	let g:statline_no_encoding_string = 'No Encoding'
+endif
 if g:statline_show_encoding
-    set statusline+=[%{&ff}→%{strlen(&fenc)?&fenc:'No\ Encoding'}]
+    set statusline+=[%{&ff}→%{strlen(&fenc)?&fenc:g:statline_no_encoding_string}]
 endif
 
 " separation between left/right aligned items


### PR DESCRIPTION
This allows statline users to have their own string printed when
encoding is not known. For example, one can set it to a much shorter:

```
let g:statline_no_encoding_string = 'NONE'
```
