### PR TITLE
make the indent warning more fool proof

### DIFF
--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -187,18 +187,26 @@ if !exists('g:statline_mixed_indent')
     let g:statline_mixed_indent = 1
 endif
 
+"return '[&et]' if &et is set wrong
+"return '[mixed-indenting]' if spaces and tabs are used to indent
+"return an empty string if everything is fine
 function! StatlineTabWarning()
     if !exists("b:statline_indent_warning")
+        let b:statline_indent_warning = ''
+
+        if !&modifiable
+            return b:statline_indent_warning
+        endif
+
         let tabs = search('^\t', 'nw') != 0
-        " ignore spaces just before JavaDoc style comments
-        let spaces = search('^ \+\*\@!', 'nw') != 0
-        let mixed = search('^\( \+\t\|\t\+ \+\*\@!\)', 'nw') != 0
-        if mixed
+
+        "find spaces that arent used as alignment in the first indent column
+        let spaces = search('^ \{' . &ts . ',}[^\t]', 'nw') != 0
+
+        if tabs && spaces
             let b:statline_indent_warning =  '[mixed-indenting]'
         elseif (spaces && !&et) || (tabs && &et)
             let b:statline_indent_warning = '[&et]'
-        else
-            let b:statline_indent_warning = ''
         endif
     endif
     return b:statline_indent_warning


### PR DESCRIPTION
Allow spaces to be used to align at the start of the line up to one tabstop in width.

Previously we checked for any run of spaces not followed by a \* (i.e. for long c style comments)

This worked fine for stuff like

```
/*
 * comment at the start of the line
 */
```

but did not catch the case where a long comment was > 1 indent level in and indented with spaces instead of tabs. e.g. a file is indented with tabs and has

```
--->--->/*
         * omg this should have been indented with tabs and aligned with
         * a space
         */
--->--->int main() {
--->--->}
```

It also did not allow for alignment that occurring at less than one indent level, e.g. (assuming tabstop is set to 8)

```
foo("bar",
    "baz");
```

My version can still break in this case (if &tabstop is set to <= 4) but it will report less false positives.
