### PR TITLE
Allow showing the full file path

### DIFF
--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -68,6 +68,8 @@ endif
 
 if exists('g:statline_filename_relative')
     set statusline+=%1*[%f]%*
+elseif exists('g:statline_filename_absolute')
+    set statusline+=%1*[%F]%*
 else
     set statusline+=%1*[%t]%*
 endif


### PR DESCRIPTION
I prefer seeing the full file path all the time instead of a relative path, so I added a new variable (`g:statline_filename_absolute`) to allow this.  It's an opt-in feature, though, so everything should be backward compatible.
