### PR TITLE
display virtual column number

### DIFF
--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -111,7 +111,7 @@ set statusline+=%=
 " ---- current line and column ----
 
 " (-:left align, 14:minwid, l:line, L:nLines, c:column)
-set statusline+=%-14(\ L%l/%L:C%c\ %)
+set statusline+=%-14(\ L%l/%L:C%c%V\ %)
 
 
 " ----  scroll percent ----


### PR DESCRIPTION
Using %V keeps this unobtrusive, as the virtual column number is only ever displayed if it is different from the column number.
