### PR TITLE
Add support to vim-obsession

### DIFF
--- a/plugin/statline.vim
+++ b/plugin/statline.vim
@@ -134,6 +134,16 @@ endif
 " ====== plugins ======
 
 
+" ---- Obsess ----
+
+if !exists('g:statline_obsess')
+    let g:statline_obsess = 0
+endif
+if g:statline_obsess
+    set statusline+=\ %2*%{exists('g:loaded_obsession')?ObsessionStatus():''}%*
+endif
+
+
 " ---- RVM ----
 
 if !exists('g:statline_rvm')


### PR DESCRIPTION
## Adds support to [vim-obsession](https://github.com/tpope/vim-obsession) plugin

I recently started using `:Obsess` to auto keep track of my vim session and I wanted to have a visual aid in the `statusline` to help me keep track of its state.

This PR just adds support to **vim-obsession** to the plugins list.

## Screenshots

**Plugin not running**

![screen shot 2018-03-26 at 11 47 31 am](https://user-images.githubusercontent.com/220900/37917271-f386a980-30eb-11e8-8b3a-6d57d8ac6d15.png)

**Plugin running, session track active**

![screen shot 2018-03-26 at 11 48 16 am](https://user-images.githubusercontent.com/220900/37917296-08e13408-30ec-11e8-927b-0d27d0427714.png)

**Plugin running, session track paused**

![screen shot 2018-03-26 at 11 48 40 am](https://user-images.githubusercontent.com/220900/37917312-14060c8c-30ec-11e8-9adf-9ad8d62bc664.png)
